### PR TITLE
Fix crawler when kktix page no display ticket count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # PyCon TW Ticket Sales Status Tracking Bot
 
 ## Description
-This bot is developed for PyCon TW staffs to track the sales status of ticket. And Bot will fetch the ticket sales status and send the notifications every Sunday.
+This bot is developed for PyCon TW staffs to track the sales status of ticket. Bot will fetch the ticket sales status and send the notifications to assigned channel in specific time.
 ## Commands list
 
 - `!kktix_status`: Show the sales status of kktix page.
 
 ## Token
 Create a `.env` file.
+
 ```
 TOKEN='YOUR_TOKEN'
 NOTIFY_CHANNEL_ID='CHANNEL_ID'
+NOTIFY_TIME='Sunday-14:00'
 ```

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 load_dotenv()
 TOKEN = os.getenv("TOKEN")
 NOTIFY_CHANNEL_ID = os.getenv("NOTIFY_CHANNEL_ID")
-target_time = str("Sunday 14:00")
+NOTIFY_TIME = os.getenv("NOTIFY_TIME")
 
 client = commands.Bot(command_prefix="!")
 
@@ -46,8 +46,8 @@ async def time_task():
     await client.wait_until_ready()
     client.channel = client.get_channel(int(NOTIFY_CHANNEL_ID))
     while not client.is_closed():
-        now_time = datetime.datetime.now().strftime("%A %H:%M")
-        if now_time == target_time:
+        now_time = datetime.datetime.now().strftime("%A-%H:%M")
+        if now_time == NOTIFY_TIME:
             msg = "PyCon TW 2021 本週售票狀況為：\n" + kktix_pycontw2021_all()
             await client.channel.send(msg)
             await asyncio.sleep(60)

--- a/main.py
+++ b/main.py
@@ -21,7 +21,10 @@ def kktix_count(web):
     r = requests.get(web)
     soup = BeautifulSoup(r.text, "html.parser")
     ticket_count = soup.find("span", class_="info-count")
-    return ticket_count.text
+    if ticket_count != None:
+        return ticket_count.text
+    else:
+        return "N/A"
 
 
 def kktix_pycontw2021_all():

--- a/main.py
+++ b/main.py
@@ -12,8 +12,7 @@ from dotenv import load_dotenv
 load_dotenv()
 TOKEN = os.getenv("TOKEN")
 NOTIFY_CHANNEL_ID = os.getenv("NOTIFY_CHANNEL_ID")
-NOTIFY_TIME = os.getenv("NOTIFY_TIME")
-
+NOTIFY_TIME = os.getenv("NOTIFY_TIME", default="Sunday-14:00")
 client = commands.Bot(command_prefix="!")
 
 
@@ -21,7 +20,7 @@ def kktix_count(web):
     r = requests.get(web)
     soup = BeautifulSoup(r.text, "html.parser")
     ticket_count = soup.find("span", class_="info-count")
-    if ticket_count != None:
+    if ticket_count:
         return ticket_count.text
     else:
         return "N/A"


### PR DESCRIPTION
## Description

Fix crawler when kktix page didn't display ticket count. [1]

[1] In order to cooperate with the marketing strategy, sometimes the kktix page will hide the ticket count.

## Changelog

- fix(main.py): fix bug for crawler kktix page no display count
- refactor(main.py): move notify_time argument to dotenv file
- docs(README.md): update variables of dotenv file